### PR TITLE
Make add_host not need two logins

### DIFF
--- a/common
+++ b/common
@@ -24,8 +24,6 @@ usage() {
   echo "  common add_host <user>@<host>"
   echo "  common run \"<unix command>\""
   echo " "
-  echo "NOTE: add_host will require login twice "
-  echo " "
 
 } 
 
@@ -34,8 +32,8 @@ add_host() {
 
   host=$1
   
-  ssh $host mkdir -p '~/.ssh'
-  cat ~/.ssh/id_rsa.pub | ssh $host 'cat >> ~/.ssh/authorized_keys'
+  local public_key=$(cat ~/.ssh/id_rsa.pub)
+  ssh $host "mkdir -p ~/.ssh && echo \"$public_key\" >> ~/.ssh/authorized_keys"
   echo $host >> ~/.config/common.cfg
 
 }


### PR DESCRIPTION
This is an initial attempt to make your add_host command not need two logins to work :) With this change it should only do one login.

I don't really have much time to setup a host to test it with at the moment, but if you're using it, you will probably be able to test it faster than me.

Let me know if you like it and it works for you!

I mainly shared this to show you one more way of doing it. I think that the best way would be to use the `ssh-copy-id` command, which would look as follows:

    ssh-copy-id -i ~/.ssh/id_rsa.pub $host